### PR TITLE
Fix broken file with unicode strings.

### DIFF
--- a/xlwt/BIFFRecords.py
+++ b/xlwt/BIFFRecords.py
@@ -95,7 +95,7 @@ class SharedStringTable(object):
     def _add_to_sst(self, s):
         u_str = upack2(s, self.encoding)
 
-        is_unicode_str = u_str[2] == b'\x01'
+        is_unicode_str = u_str[2] == 0x01
         if is_unicode_str:
             atom_len = 5 # 2 byte -- len,
                          # 1 byte -- options,
@@ -110,7 +110,7 @@ class SharedStringTable(object):
 	
     def _add_rt_to_sst(self, rt):
         rt_str, rt_fr = upack2rt(rt, self.encoding)
-        is_unicode_str = rt_str[2] == b'\x09'
+        is_unicode_str = rt_str[2] == 0x09
         if is_unicode_str:
             atom_len = 7 # 2 byte -- len,
                          # 1 byte -- options,


### PR DESCRIPTION
```
import xlwt

book = xlwt.Workbook()
sheet = book.add_sheet('A')

for row in range(200):
    val = u'\u3042' * row
    sheet.write(row, 0, val)

book.save('test.xls')
```
