### PR TITLE
Compare bitmap header with byte string.

### DIFF
--- a/xlwt/Bitmap.py
+++ b/xlwt/Bitmap.py
@@ -204,7 +204,7 @@ def _process_bitmap(bitmap):
     if len(data) <= 0x36:
         raise Exception("bitmap doesn't contain enough data.")
     # The first 2 bytes are used to identify the bitmap.
-    if (data[:2] != "BM"):
+    if (data[:2] != b"BM"):
         raise Exception("bitmap doesn't appear to to be a valid bitmap image.")
     # Remove bitmap data: ID.
     data = data[2:]


### PR DESCRIPTION
I think without this fix it's not possible to insert an image with python3, even with a correct bitmap header we checked `b"BM" == "BM"` and that always `False`.
With this change the comparison still works with Python 2.7.3.
